### PR TITLE
Add payslip log for John Doe

### DIFF
--- a/payslip-log-john-doe
+++ b/payslip-log-john-doe
@@ -1,0 +1,10 @@
+---
+event: payslip_generated
+timestamp: 2025-09-04T07:34:30Z
+contributor: xpertforextradeinc
+status: ✅ Success
+employee: John Doe
+net_pay: $2,500.00
+currency: USD
+output: PDF
+---


### PR DESCRIPTION
Documented a successful payslip generation event for employee John Doe.   Includes timestamp, contributor ID, net pay, currency, and output format.   Log entry added to `/logs/payslip-john-doe.md` for audit traceability and contributor visibility.   Status marked ✅ to indicate successful generation with no errors.   This update supports onboarding clarity and reinforces audit hygiene across the payslip module.